### PR TITLE
Build docset in the Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:jammy
+
+RUN apt-get update && apt-get install --yes \
+    rake \
+    ruby-bundler \
+    ruby-dev \
+    racc \
+    gcc \
+    make \
+    libyaml-dev
+
+COPY . /stage
+WORKDIR /stage
+
+RUN bundle
+ENTRYPOINT ["/bin/bash", "-c", "rake && cp *.docset output/"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ How to use
 
     % open Tailwind_CSS.docset
 
+Or to build in Docker container:
+
+    % docker build -t docset .
+    % mkdir -p output
+    # docker run -v`pwd`:/stage docset
+
 Requirements
 ------------
 


### PR DESCRIPTION
I'm not a ruby developer and don't want to install on my main system ruby and all necessary dependencies just to build a docset. Building in an isolated docker container seems a good option for guys like me.

Warning. Right now build fails with syntax error. Problem described in https://github.com/knu/docset-tailwindcss/issues/2