### PR TITLE
Respect user's light/dark mode choice

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -452,6 +452,7 @@ task :build => [DOCS_DIR, ICON_FILE] do |t|
 
       doc.at_css('html').then do |html|
         html.remove_class(html.classes.grep(/(?:\A|:)\[--scroll-mt:/))
+        html.remove_class('dark')
 
         html.prepend_child(Nokogiri::XML::Comment.new(doc, " Online page at #{uri} "))
       end


### PR DESCRIPTION
There is this static `dark` class in the `html` elements.

Normally, this class has to be added by the display application.
However, since the class is in static HTML, the documents are always displayed in dark mode.

Can we respect both choices?